### PR TITLE
fixed bug with search post for 400 status

### DIFF
--- a/controllers/group.js
+++ b/controllers/group.js
@@ -37,7 +37,7 @@ router
 
 // endpoint to retrieve groups for fuzzy search
 router.route("/search").post(async (req, res) => {
-	if (req.body.column && req.body.row) {
+	if (req.body.column !== undefined && req.body.row !== undefined) {
 		if (req.body.column === "location") {
 			// Takes zip code and optional radius from request body
 			const zip = req.body.row;


### PR DESCRIPTION
# Description

Refactored check to look for undefined instead of falsey (where empty strings would trigger falsey)

## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
