### PR TITLE
Feat/api allegiances

### DIFF
--- a/controllers/allegiance.js
+++ b/controllers/allegiance.js
@@ -5,37 +5,35 @@ const Allegiances = require("../models/allegiances");
 const router = express.Router();
 
 router
-	.route("/")
-	.get(async (req, res) => {
-		const allegiances = await Allegiances.find();
-		res.status(200).json({ allegiances });
-	})
-	.post(async (req, res) => {
-		const newAllegiance = await Allegiances.add(req.body);
-		console.log("trying to add allegiance:", newAllegiance);
-		res.status(201).json({ newAllegiance });
-	});
+  .route("/")
+  .get(async (req, res) => {
+    const allegiances = await Allegiances.find();
+    res.status(200).json({ allegiances });
+  })
+  .post(async (req, res) => {
+    const newAllegiance = await Allegiances.add(req.body);
+    res.status(201).json({ newAllegiance });
+  });
 
 router
-	.route("/:id")
-	.put(async (req, res) => {
-		const { id } = req.params;
-		const changes = req.body;
-		const filter = { id: id };
-		const updated = await Allegiances.update(filter, changes);
-		res.status(200).json({ updated });
-	})
-	.delete(async (req, res) => {
-		const { id } = req.params;
-		const filter = { id: id };
-		const deleted = await Allegiances.remove(filter);
-		res.status(200).json({ deleted });
-	})
-	.get(async (req, res) => {
-		const { id } = req.params;
-		const filter = { id: id };
-		const allegiance = await Allegiances.find(filter);
-		res.status(200).json({ allegiance });
-	});
+  .route("/:id")
+  .put(async (req, res) => {
+    const { id } = req.params;
+    const changes = req.body;
+    const filter = { id: id };
+    const updated = await Allegiances.update(filter, changes);
+    res.status(200).json({ updated });
+  })
+  .delete(async (req, res) => {
+    const { id } = req.params;
+    const filter = { id: id };
+    const deleted = await Allegiances.remove(filter);
+    res.status(200).json({ deleted });
+  })
+  .get(async (req, res) => {
+    const { id } = req.params;
+    const allegiance = await Allegiances.find({ id }).first();
+    res.status(200).json({ allegiance });
+  });
 
 module.exports = router;

--- a/controllers/allegiance.js
+++ b/controllers/allegiance.js
@@ -19,15 +19,12 @@ router
   .route("/:id")
   .put(async (req, res) => {
     const { id } = req.params;
-    const changes = req.body;
-    const filter = { id: id };
-    const updated = await Allegiances.update(filter, changes);
+    const updated = await Allegiances.update({ id }, req.body);
     res.status(200).json({ updated });
   })
   .delete(async (req, res) => {
     const { id } = req.params;
-    const filter = { id: id };
-    const deleted = await Allegiances.remove(filter);
+    const deleted = await Allegiances.remove({ id });
     res.status(200).json({ deleted });
   })
   .get(async (req, res) => {

--- a/controllers/allegiance.js
+++ b/controllers/allegiance.js
@@ -19,18 +19,27 @@ router
   .route("/:id")
   .put(async (req, res) => {
     const { id } = req.params;
+    const allegianceExists = await Allegiances.find({ id }).first();
+    if (!allegianceExists) {
+      res.status(404).json({ message: "That resource does not exist." });
+    }
     const updated = await Allegiances.update({ id }, req.body);
     res.status(200).json({ updated });
   })
   .delete(async (req, res) => {
     const { id } = req.params;
+
     const deleted = await Allegiances.remove({ id });
-    res.status(200).json({ deleted });
+    deleted
+      ? res.status(200).json({ deleted })
+      : res.status(404).json({ message: "That resource does not exist." });
   })
   .get(async (req, res) => {
     const { id } = req.params;
     const allegiance = await Allegiances.find({ id }).first();
-    res.status(200).json({ allegiance });
+    allegiance
+      ? res.status(200).json({ allegiance })
+      : res.status(404).json({ message: "That resource does not exist." });
   });
 
 module.exports = router;

--- a/controllers/group_allegiance.js
+++ b/controllers/group_allegiance.js
@@ -68,7 +68,7 @@ router
     const groupAllegiances = await GroupsAllegiances.find({
       "g_a.id": id
     }).first();
-    if (groupAllegiances && groupAllegiances.id) {
+    if (groupAllegiances) {
       res.status(200).json({ groupAllegiances });
     } else {
       res

--- a/controllers/group_allegiance.js
+++ b/controllers/group_allegiance.js
@@ -10,83 +10,71 @@ const validation = require("../middleware/dataValidation");
 const { groupAllegianceSchema } = require("../schemas");
 
 router
-	.route("/")
-	.get(async (req, res) => {
-		// check if there are filters present on request body, if so pass filter to find function
-		if (Object.keys(req.body).length > 0) {
-			const groupAllegiance = await GroupsAllegiances.find(req.body);
-			res.status(200).json({
-				groupAllegiance
-			});
-			// if there are no filters being passed on request body, send entire listing of users
-		} else {
-			const groupAllegiance = await GroupsAllegiances.find();
-			res.status(200).json({
-				groupAllegiance
-			});
-		}
-	})
-	.post(validation(groupAllegianceSchema), async (req, res) => {
-		const { allegiance_id, group_id } = req.body;
-		const allegiance = await Allegiances.find({
-			id: allegiance_id
-		}).first();
-		const group = await Groups.find({
-			id: group_id
-		}).first();
-		if (allegiance && group) {
-			const newGroupAllegiances = await GroupsAllegiances.add(req.body);
-			res.status(201).json({
-				newGroupAllegiances
-			});
-		} else {
-			res.status(404).json({
-				message:
-					"Group id provided or Allegiance id provided does not exist, please double check inputs"
-			});
-		}
-	});
+  .route("/")
+  .get(async (req, res) => {
+    // check if there are filters present on request body, if so pass filter to find function
+    if (Object.keys(req.body).length > 0) {
+      const groupAllegiance = await GroupsAllegiances.find(req.body);
+      res.status(200).json({
+        groupAllegiance
+      });
+      // if there are no filters being passed on request body, send entire listing of users
+    } else {
+      const groupAllegiance = await GroupsAllegiances.find();
+      res.status(200).json({
+        groupAllegiance
+      });
+    }
+  })
+  .post(validation(groupAllegianceSchema), async (req, res) => {
+    const { allegiance_id, group_id } = req.body;
+    const allegiance = await Allegiances.find({
+      id: allegiance_id
+    }).first();
+    const group = await Groups.find({
+      id: group_id
+    }).first();
+    if (allegiance && group) {
+      const newGroupAllegiances = await GroupsAllegiances.add(req.body);
+      res.status(201).json({
+        newGroupAllegiances
+      });
+    } else {
+      res.status(404).json({
+        message:
+          "Group id provided or Allegiance id provided does not exist, please double check inputs"
+      });
+    }
+  });
 
 router
-	.route("/:id")
-	// put might be useless - what situation would we use this?
-	.put(validation(groupAllegianceSchema), async (req, res) => {
-		const { id } = req.params;
-		const changes = req.body;
-		const relationExists = await GroupsAllegiances.find({ id }).first();
-		if (!relationExists) {
-			res
-				.status(404)
-				.json({ message: "That group to allegiance pairing does not exist." });
-		} else {
-			const updated = await GroupsAllegiances.update({ id }, changes);
-			res.status(200).json({ updated });
-		}
-	})
-	.delete(async (req, res) => {
-		const { id } = req.params;
+  .route("/:id")
+  .delete(async (req, res) => {
+    const { id } = req.params;
 
-		const deleted = await GroupsAllegiances.remove({ id });
-		if (deleted) {
-			res
-				.status(200)
-				.json({ message: "The group to allegiance pairing has been deleted." });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That group to allegiance pairing does not exist." });
-		}
-	})
-	.get(async (req, res) => {
-		const { id } = req.params;
-		const groupAllegiances = await GroupsAllegiances.find({ id }).first();
-		if (groupAllegiances && groupAllegiances.id) {
-			res.status(200).json({ groupAllegiances });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That group to allegiance pairing does not exist." });
-		}
-	});
+    const deleted = await GroupsAllegiances.remove({ id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The group to allegiance pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That group to allegiance pairing does not exist." });
+    }
+  })
+  .get(async (req, res) => {
+    const { id } = req.params;
+    const groupAllegiances = await GroupsAllegiances.find({
+      "g_a.id": id
+    }).first();
+    if (groupAllegiances && groupAllegiances.id) {
+      res.status(200).json({ groupAllegiances });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That group to allegiance pairing does not exist." });
+    }
+  });
 
 module.exports = router;

--- a/controllers/tests/user.spec.js
+++ b/controllers/tests/user.spec.js
@@ -22,7 +22,7 @@ describe("user router", () => {
       expect(response.status).toBe(200);
       expect(response.body.users.length).toEqual(500);
     });
-    it.skip("fails without valid authentication", async () => {
+    it("fails without valid authentication", async () => {
       const response = await request(server).get("/api/users");
       expect(response.status).toBe(500);
       expect(response.body).toEqual({});
@@ -49,6 +49,9 @@ describe("user router", () => {
         .send({ ...newUser, email: null })
         .set({ Authorization: `Bearer ${token}` });
       expect(response.status).toBe(400);
+      expect(response.body.error).toBe(
+        'Error during POST at /api/users: "email" must be a string'
+      );
     });
   });
 

--- a/middleware/dataValidation.js
+++ b/middleware/dataValidation.js
@@ -5,11 +5,8 @@ module.exports = schema => {
   return (req, res, next) => {
     const { error } = Joi.validate(req.body, schema);
     if (error) {
-      console.log(error);
       return res.status(400).json({
-        error: `Error during ${req.method} at ${req.originalUrl}: ${
-          error.details[0].message
-        }`
+        error: `Error during ${req.method} at ${req.originalUrl}: ${error.details[0].message}`
       });
     }
     next();

--- a/models/allegiances.js
+++ b/models/allegiances.js
@@ -10,7 +10,7 @@ module.exports = {
 function add(allegiance) {
   return db("allegiances")
     .insert(allegiance, ["*"])
-    .then(u => find({ id: u[0].id }).first());
+    .then(a => find({ id: a[0].id }).first());
 }
 
 function find(filters) {
@@ -35,8 +35,7 @@ function update(filter, changes) {
   return db("allegiances")
     .update(changes, "*")
     .where(filter)
-    .then(u => find({ id: u[0].id }).first())
-    
+    .then(a => find({ id: a[0].id }).first());
 }
 
 function remove(filter) {

--- a/models/groups_allegiances.js
+++ b/models/groups_allegiances.js
@@ -1,67 +1,67 @@
 const db = require("../data/db-config");
 
 module.exports = {
-	add,
-	find,
-	update,
-	remove
+  add,
+  find,
+  update,
+  remove
 };
 
 function add(group_allegiance) {
-	return (
-		db("groups_allegiances")
-			// allegiance_id, group_id required
-			.insert(group_allegiance, ["*"])
-			.then(g_a => find({ id: g_a[0].id }).first())
-	);
+  return (
+    db("groups_allegiances")
+      // allegiance_id, group_id required
+      .insert(group_allegiance, ["*"])
+      .then(g_a => find({ "g_a.id": g_a[0].id }).first())
+  );
 }
 
 function find(filters) {
-	if (filters) {
-		return db("groups_allegiances as g_a")
-			.leftJoin("allegiances as a", "a.id", "g_a.allegiance_id")
-			.leftJoin("groups as g", "g.id", "g_a.group_id")
-			.where(filters)
-			.select(
-				"g_a.id as id",
-				"g.id as group_id",
-				"group_name",
-				"a.id as allegiance_id",
-				"a.allegiance_name as allegiance_name",
-				"a.image as allegiance_image",
-				"a.sport as sport"
-			);
-	} else {
-		return db("groups_allegiances as g_a")
-			.leftJoin("allegiances as a", "a.id", "g_a.allegiance_id")
-			.leftJoin("groups as g", "g.id", "g_a.group_id")
-			.select(
-				"g_a.id as id",
-				"g.id as group_id",
-				"group_name",
-				"a.id as allegiance_id",
-				"a.allegiance_name as allegiance_name",
-				"a.image as allegiance_image",
-				"a.sport as sport"
-			);
-	}
+  if (filters) {
+    return db("groups_allegiances as g_a")
+      .leftJoin("allegiances as a", { "a.id": "g_a.allegiance_id" })
+      .leftJoin("groups as g", { "g.id": "g_a.group_id" })
+      .where(filters)
+      .select(
+        "g_a.id as id",
+        "g.id as group_id",
+        "group_name",
+        "a.id as allegiance_id",
+        "a.allegiance_name as allegiance_name",
+        "a.image as allegiance_image",
+        "a.sport as sport"
+      );
+  } else {
+    return db("groups_allegiances as g_a")
+      .leftJoin("allegiances as a", { "a.id": "g_a.allegiance_id" })
+      .leftJoin("groups as g", { "g.id": "g_a.group_id" })
+      .select(
+        "g_a.id as id",
+        "g.id as group_id",
+        "group_name",
+        "a.id as allegiance_id",
+        "a.allegiance_name as allegiance_name",
+        "a.image as allegiance_image",
+        "a.sport as sport"
+      );
+  }
 }
 
 function update(filter, changes) {
-	// only allow one update at a time, so uses .first()
-	return db("groups_allegiances")
-		.update(changes, ["*"])
-		.where(filter)
-		.then(g_a =>
-			find({
-				id: g_a[0].id
-			}).first()
-		);
+  // only allow one update at a time, so uses .first()
+  return db("groups_allegiances")
+    .update(changes, ["*"])
+    .where(filter)
+    .then(g_a =>
+      find({
+        id: g_a[0].id
+      }).first()
+    );
 }
 
 function remove(filter) {
-	// only returns the number of deleted entries
-	return db("groups_allegiances")
-		.where(filter)
-		.del();
+  // only returns the number of deleted entries
+  return db("groups_allegiances")
+    .where(filter)
+    .del();
 }

--- a/models/groups_allegiances.js
+++ b/models/groups_allegiances.js
@@ -3,7 +3,6 @@ const db = require("../data/db-config");
 module.exports = {
   add,
   find,
-  update,
   remove
 };
 
@@ -45,18 +44,6 @@ function find(filters) {
         "a.sport as sport"
       );
   }
-}
-
-function update(filter, changes) {
-  // only allow one update at a time, so uses .first()
-  return db("groups_allegiances")
-    .update(changes, ["*"])
-    .where(filter)
-    .then(g_a =>
-      find({
-        id: g_a[0].id
-      }).first()
-    );
 }
 
 function remove(filter) {


### PR DESCRIPTION
# Description

Existing endpoints for `allegiances` and `groups_allegiances` all tested and updated if necessary. All verified as working in Postman.

Some query syntax for Knex needed to be adjusted for use of join aliases (ex: GroupsAllegiances.find({id}) --> GroupsAllegiances.find({"g_a.id" : id}) since that method uses alias for "groups_allegiances AS g_a")

Deleted PUT for groups_allegiances by id, as currently there is no projected need for it in the app. If user testing proves otherwise, will include it again.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
