### PR TITLE
:recycle: Make auth response consistent

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -45,7 +45,8 @@ router.route("/").post(async (req, res) => {
 	} else {
 		// Add user to database if email does not exist
 		const newUser = await Users.add(req.body);
-		res.status(201).json({ newUser });
+		const userInfo = { newUser };
+		res.status(201).json({ userInfo });
 	}
 });
 


### PR DESCRIPTION
Auth response to new user sends back userInfo instead of newUser

# Description

Auth response to new user sends back userInfo instead of newUser

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
