### PR TITLE
:recycle: Uniques for g_u, g_a, u_a tables

### DIFF
--- a/data/migrations/20190815113741_groups_allegiances.js
+++ b/data/migrations/20190815113741_groups_allegiances.js
@@ -19,6 +19,8 @@ exports.up = function(knex) {
 			.inTable("allegiances")
 			.onDelete("CASCADE")
 			.onUpdate("CASCADE");
+
+		groups_allegiances.unique(["group_id", "allegiance_id"]);
 	});
 };
 

--- a/data/migrations/20190815113751_groups_users.js
+++ b/data/migrations/20190815113751_groups_users.js
@@ -20,6 +20,8 @@ exports.up = function(knex) {
 			.onDelete("CASCADE")
 			.onUpdate("CASCADE");
 		groups_users.timestamps(true, true);
+
+		groups_users.unique(["user_id, group_id"]);
 	});
 };
 

--- a/data/migrations/20190815113751_groups_users.js
+++ b/data/migrations/20190815113751_groups_users.js
@@ -21,7 +21,7 @@ exports.up = function(knex) {
 			.onUpdate("CASCADE");
 		groups_users.timestamps(true, true);
 
-		groups_users.unique(["user_id, group_id"]);
+		groups_users.unique(["user_id", "group_id"]);
 	});
 };
 

--- a/data/migrations/20190825172030_users_allegiances.js
+++ b/data/migrations/20190825172030_users_allegiances.js
@@ -19,6 +19,8 @@ exports.up = function(knex) {
 			.inTable("allegiances")
 			.onDelete("CASCADE")
 			.onUpdate("CASCADE");
+
+		users_allegiances.unique(["user_id, allegiance_id"]);
 	});
 };
 

--- a/data/migrations/20190825172030_users_allegiances.js
+++ b/data/migrations/20190825172030_users_allegiances.js
@@ -20,7 +20,7 @@ exports.up = function(knex) {
 			.onDelete("CASCADE")
 			.onUpdate("CASCADE");
 
-		users_allegiances.unique(["user_id, allegiance_id"]);
+		users_allegiances.unique(["user_id", "allegiance_id"]);
 	});
 };
 


### PR DESCRIPTION
Make relationships unique for groups_users, groups_allegiances, and users_allegiances tables

# Description

Make relationships unique for groups_users, groups_allegiances, and users_allegiances tables

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

