### PR TITLE
Added new delete endpoints using foreign keys

### DIFF
--- a/controllers/group_allegiance.js
+++ b/controllers/group_allegiance.js
@@ -10,74 +10,88 @@ const validation = require("../middleware/dataValidation");
 const { groupAllegianceSchema } = require("../schemas");
 
 router
-	.route("/")
-	.get(async (req, res) => {
-		// check if there are filters present on request body, if so pass filter to find function
-		if (Object.keys(req.body).length > 0) {
-			const groupAllegiance = await GroupsAllegiances.find(req.body);
-			res.status(200).json({
-				groupAllegiance
-			});
-			// if there are no filters being passed on request body, send entire listing of associations
-		} else {
-			const groupAllegiance = await GroupsAllegiances.find();
-			res.status(200).json({
-				groupAllegiance
-			});
-		}
-	})
-	.post(validation(groupAllegianceSchema), async (req, res) => {
-		const { allegiance_id, group_id } = req.body;
-		// Check if allegiance exists
-		const allegiance = await Allegiances.find({
-			id: allegiance_id
-		}).first();
-		// Check if group exists
-		const group = await Groups.find({
-			id: group_id
-		}).first();
-		if (allegiance && group) {
-			// if both allegiance and group exists, create relationship between the two
-			const newGroupAllegiances = await GroupsAllegiances.add(req.body);
-			res.status(201).json({
-				newGroupAllegiances
-			});
-		} else {
-			res.status(404).json({
-				message:
-					"Group id provided or Allegiance id provided does not exist, please double check inputs"
-			});
-		}
-	});
+  .route("/")
+  .get(async (req, res) => {
+    // check if there are filters present on request body, if so pass filter to find function
+    if (Object.keys(req.body).length > 0) {
+      const groupAllegiance = await GroupsAllegiances.find(req.body);
+      res.status(200).json({
+        groupAllegiance
+      });
+      // if there are no filters being passed on request body, send entire listing of associations
+    } else {
+      const groupAllegiance = await GroupsAllegiances.find();
+      res.status(200).json({
+        groupAllegiance
+      });
+    }
+  })
+  .post(validation(groupAllegianceSchema), async (req, res) => {
+    const { allegiance_id, group_id } = req.body;
+    // Check if allegiance exists
+    const allegiance = await Allegiances.find({
+      id: allegiance_id
+    }).first();
+    // Check if group exists
+    const group = await Groups.find({
+      id: group_id
+    }).first();
+    if (allegiance && group) {
+      // if both allegiance and group exists, create relationship between the two
+      const newGroupAllegiances = await GroupsAllegiances.add(req.body);
+      res.status(201).json({
+        newGroupAllegiances
+      });
+    } else {
+      res.status(404).json({
+        message:
+          "Group id provided or Allegiance id provided does not exist, please double check inputs"
+      });
+    }
+  })
+  // Delete by group and allegiance IDs
+  .delete(validation(groupAllegianceSchema), async (req, res) => {
+    const { group_id, allegiance_id } = req.body;
+    const deleted = await GroupsAllegiances.remove({ group_id, allegiance_id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The group to allegiance pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That group to allegiance pairing does not exist." });
+    }
+  });
 
 router
-	.route("/:id")
-	.delete(async (req, res) => {
-		const { id } = req.params;
-		const deleted = await GroupsAllegiances.remove({ id });
-		if (deleted) {
-			res
-				.status(200)
-				.json({ message: "The group to allegiance pairing has been deleted." });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That group to allegiance pairing does not exist." });
-		}
-	})
-	.get(async (req, res) => {
-		const { id } = req.params;
-		// Check if group to allegiance pairing exists
-		const groupAllegiances = await GroupsAllegiances.find({
-			"g_a.id": id
-		}).first();
-		if (groupAllegiances) {
-			res.status(200).json({ groupAllegiances });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That group to allegiance pairing does not exist." });
-		}
-	});
+  .route("/:id")
+  .delete(async (req, res) => {
+    const { id } = req.params;
+    const deleted = await GroupsAllegiances.remove({ id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The group to allegiance pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That group to allegiance pairing does not exist." });
+    }
+  })
+  .get(async (req, res) => {
+    const { id } = req.params;
+    // Check if group to allegiance pairing exists
+    const groupAllegiances = await GroupsAllegiances.find({
+      "g_a.id": id
+    }).first();
+    if (groupAllegiances) {
+      res.status(200).json({ groupAllegiances });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That group to allegiance pairing does not exist." });
+    }
+  });
 
 module.exports = router;

--- a/controllers/group_user.js
+++ b/controllers/group_user.js
@@ -10,141 +10,155 @@ const validation = require("../middleware/dataValidation");
 const { groupUserSchema } = require("../schemas");
 
 router
-	.route("/")
-	.get(async (req, res) => {
-		// check if there are filters present on request body, if so pass filter to find function
-		if (Object.keys(req.body).length > 0) {
-			const groupUsers = await GroupsUsers.find(req.body);
-			res.status(200).json({
-				groupUsers
-			});
-			// if there are no filters being passed on request body, send entire listing of associations
-		} else {
-			const groupUsers = await GroupsUsers.find();
-			res.status(200).json({
-				groupUsers
-			});
-		}
-	})
-	.post(validation(groupUserSchema), async (req, res) => {
-		const { user_id, group_id } = req.body;
-		// Check if user exists
-		const user = await Users.find({
-			id: user_id
-		}).first();
-		// Check if group exists
-		const group = await Groups.find({
-			id: group_id
-		}).first();
-		if (user && group) {
-			// if both allegiance and group exists, create relationship between the two
-			const newGroupUsers = await GroupsUsers.add(req.body);
-			res.status(201).json({
-				newGroupUsers
-			});
-		} else {
-			res.status(404).json({
-				message:
-					"User id provided or Group id provided does not exist, please double check inputs"
-			});
-		}
-	});
+  .route("/")
+  .get(async (req, res) => {
+    // check if there are filters present on request body, if so pass filter to find function
+    if (Object.keys(req.body).length > 0) {
+      const groupUsers = await GroupsUsers.find(req.body);
+      res.status(200).json({
+        groupUsers
+      });
+      // if there are no filters being passed on request body, send entire listing of associations
+    } else {
+      const groupUsers = await GroupsUsers.find();
+      res.status(200).json({
+        groupUsers
+      });
+    }
+  })
+  .post(validation(groupUserSchema), async (req, res) => {
+    const { user_id, group_id } = req.body;
+    // Check if user exists
+    const user = await Users.find({
+      id: user_id
+    }).first();
+    // Check if group exists
+    const group = await Groups.find({
+      id: group_id
+    }).first();
+    if (user && group) {
+      // if both allegiance and group exists, create relationship between the two
+      const newGroupUsers = await GroupsUsers.add(req.body);
+      res.status(201).json({
+        newGroupUsers
+      });
+    } else {
+      res.status(404).json({
+        message:
+          "User id provided or Group id provided does not exist, please double check inputs"
+      });
+    }
+  })
+  // Delete by user and group IDs
+  .delete(async (req, res) => {
+    const { group_id, user_id } = req.body;
+    const deleted = await GroupsUsers.remove({ user_id, group_id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The user to group pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That user to group pairing does not exist." });
+    }
+  });
 
 // endpoint to retrieve group relationship for logged in user
 router.route("/search").post(async (req, res) => {
-	// check for user_id and group_id in request body
-	const { user_id, group_id } = req.body;
-	// if both user_id and group_id are defined in body move along this branch
-	if (user_id !== undefined && group_id !== undefined) {
-		// find if relation between user and group entered exists, if so return find function from groups_users model
-		const relationExists = await GroupsUsers.find(req.body);
-		if (relationExists.length !== 0) {
-			res.status(200).json({
-				relationExists
-			});
-			// if relation does not already exist, check for user and group existence
-		} else {
-			const user = await Users.find({
-				id: user_id
-			}).first();
-			const group = await Groups.find({
-				id: group_id
-			}).first();
-			// if user and group exists, send group information
-			if (user && group) {
-				res.status(200).json({
-					group
-				});
-			} else {
-				res.status(404).json({
-					message:
-						"User id provided or Group id provided does not exist, please double check inputs"
-				});
-			}
-		}
-		// if either user_id and group_id are undefined return 400 message
-	} else {
-		res.status(400).json({ message: "User_id and group_id must be provided." });
-	}
+  // check for user_id and group_id in request body
+  const { user_id, group_id } = req.body;
+  // if both user_id and group_id are defined in body move along this branch
+  if (user_id !== undefined && group_id !== undefined) {
+    // find if relation between user and group entered exists, if so return find function from groups_users model
+    const relationExists = await GroupsUsers.find(req.body);
+    if (relationExists.length !== 0) {
+      res.status(200).json({
+        relationExists
+      });
+      // if relation does not already exist, check for user and group existence
+    } else {
+      const user = await Users.find({
+        id: user_id
+      }).first();
+      const group = await Groups.find({
+        id: group_id
+      }).first();
+      // if user and group exists, send group information
+      if (user && group) {
+        res.status(200).json({
+          group
+        });
+      } else {
+        res.status(404).json({
+          message:
+            "User id provided or Group id provided does not exist, please double check inputs"
+        });
+      }
+    }
+    // if either user_id and group_id are undefined return 400 message
+  } else {
+    res.status(400).json({ message: "User_id and group_id must be provided." });
+  }
 });
 
 // endpoint to retrieve all groups for a user
 router.route("/search/:user_id").get(async (req, res) => {
-	// obtain user_id from params
-	const { user_id } = req.params;
-	// find if user has any groups
-	const groups = await GroupsUsers.find({ user_id });
-	if (groups.length > 0) {
-		// if groups array is not empty, then send groups as a response
-		res.status(200).json({
-			groups
-		});
-	} else {
-		res.status(404).json({
-			message: "User id provided does not exist or has no groups"
-		});
-	}
+  // obtain user_id from params
+  const { user_id } = req.params;
+  // find if user has any groups
+  const groups = await GroupsUsers.find({ user_id });
+  if (groups.length > 0) {
+    // if groups array is not empty, then send groups as a response
+    res.status(200).json({
+      groups
+    });
+  } else {
+    res.status(404).json({
+      message: "User id provided does not exist or has no groups"
+    });
+  }
 });
 
 router
-	.route("/:id")
-	.put(validation(groupUserSchema), async (req, res) => {
-		const { id } = req.params;
-		const changes = req.body;
-		// Check if a relation between the group and user provided in the body exists
-		const relationExists = await GroupsUsers.find({ "g_u.id": id }).first();
-		if (!relationExists) {
-			res
-				.status(404)
-				.json({ message: "That user to group pairing does not exist." });
-		} else {
-			const updated = await GroupsUsers.update({ id }, changes);
-			res.status(200).json({ updated });
-		}
-	})
-	.delete(async (req, res) => {
-		const { id } = req.params;
-		const deleted = await GroupsUsers.remove({ id });
-		if (deleted) {
-			res
-				.status(200)
-				.json({ message: "The user to group pairing has been deleted." });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That user to group pairing does not exist." });
-		}
-	})
-	.get(async (req, res) => {
-		const { id } = req.params;
-		const groupUsers = await GroupsUsers.find({ "g_u.id": id }).first();
-		if (groupUsers && groupUsers.id) {
-			res.status(200).json({ groupUsers });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That user to group pairing does not exist." });
-		}
-	});
+  .route("/:id")
+  .put(validation(groupUserSchema), async (req, res) => {
+    const { id } = req.params;
+    const changes = req.body;
+    // Check if a relation between the group and user provided in the body exists
+    const relationExists = await GroupsUsers.find({ "g_u.id": id }).first();
+    if (!relationExists) {
+      res
+        .status(404)
+        .json({ message: "That user to group pairing does not exist." });
+    } else {
+      const updated = await GroupsUsers.update({ id }, changes);
+      res.status(200).json({ updated });
+    }
+  })
+  .delete(async (req, res) => {
+    const { id } = req.params;
+    const deleted = await GroupsUsers.remove({ id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The user to group pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That user to group pairing does not exist." });
+    }
+  })
+  .get(async (req, res) => {
+    const { id } = req.params;
+    const groupUsers = await GroupsUsers.find({ "g_u.id": id }).first();
+    if (groupUsers && groupUsers.id) {
+      res.status(200).json({ groupUsers });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That user to group pairing does not exist." });
+    }
+  });
 
 module.exports = router;

--- a/controllers/user_allegiance.js
+++ b/controllers/user_allegiance.js
@@ -10,74 +10,88 @@ const validation = require("../middleware/dataValidation");
 const { userAllegianceSchema } = require("../schemas");
 
 router
-	.route("/")
-	.get(async (req, res) => {
-		// check if there are filters present on request body, if so pass filter to find function
-		if (Object.keys(req.body).length > 0) {
-			const userAllegiance = await UsersAllegiances.find(req.body);
-			res.status(200).json({
-				userAllegiance
-			});
-			// if there are no filters being passed on request body, send entire listing of associations
-		} else {
-			const userAllegiance = await UsersAllegiances.find();
-			res.status(200).json({
-				userAllegiance
-			});
-		}
-	})
-	.post(validation(userAllegianceSchema), async (req, res) => {
-		const { allegiance_id, user_id } = req.body;
-		// Check if allegiance exists
-		const allegiance = await Allegiances.find({
-			id: allegiance_id
-		}).first();
-		// Check if user exists
-		const user = await Users.find({
-			id: user_id
-		}).first();
-		if (allegiance && user) {
-			// If both user and allegiance exists, create new association
-			const newUserAllegiances = await UsersAllegiances.add(req.body);
-			res.status(201).json({
-				newUserAllegiances
-			});
-		} else {
-			res.status(404).json({
-				message:
-					"User id provided or Allegiance id provided does not exist, please double check inputs"
-			});
-		}
-	});
+  .route("/")
+  .get(async (req, res) => {
+    // check if there are filters present on request body, if so pass filter to find function
+    if (Object.keys(req.body).length > 0) {
+      const userAllegiance = await UsersAllegiances.find(req.body);
+      res.status(200).json({
+        userAllegiance
+      });
+      // if there are no filters being passed on request body, send entire listing of associations
+    } else {
+      const userAllegiance = await UsersAllegiances.find();
+      res.status(200).json({
+        userAllegiance
+      });
+    }
+  })
+  .post(validation(userAllegianceSchema), async (req, res) => {
+    const { allegiance_id, user_id } = req.body;
+    // Check if allegiance exists
+    const allegiance = await Allegiances.find({
+      id: allegiance_id
+    }).first();
+    // Check if user exists
+    const user = await Users.find({
+      id: user_id
+    }).first();
+    if (allegiance && user) {
+      // If both user and allegiance exists, create new association
+      const newUserAllegiances = await UsersAllegiances.add(req.body);
+      res.status(201).json({
+        newUserAllegiances
+      });
+    } else {
+      res.status(404).json({
+        message:
+          "User id provided or Allegiance id provided does not exist, please double check inputs"
+      });
+    }
+  })
+  // Delete by user and allegiance IDs
+  .delete(validation(userAllegianceSchema), async (req, res) => {
+    const { user_id, allegiance_id } = req.body;
+    const deleted = await UsersAllegiances.remove({ user_id, allegiance_id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The user to allegiance pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That user to allegiance pairing does not exist." });
+    }
+  });
 
 router
-	.route("/:id")
-	.delete(async (req, res) => {
-		const { id } = req.params;
-		const deleted = await UsersAllegiances.remove({ id });
-		if (deleted) {
-			res
-				.status(200)
-				.json({ message: "The user to allegiance pairing has been deleted." });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That user to allegiance pairing does not exist." });
-		}
-	})
-	.get(async (req, res) => {
-		const { id } = req.params;
-		// Check if user to allegiance pairing exists
-		const userAllegiances = await UsersAllegiances.find({
-			"u_a.id": id
-		}).first();
-		if (userAllegiances) {
-			res.status(200).json({ userAllegiances });
-		} else {
-			res
-				.status(404)
-				.json({ message: "That user to allegiance pairing does not exist." });
-		}
-	});
+  .route("/:id")
+  .delete(async (req, res) => {
+    const { id } = req.params;
+    const deleted = await UsersAllegiances.remove({ id });
+    if (deleted) {
+      res
+        .status(200)
+        .json({ message: "The user to allegiance pairing has been deleted." });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That user to allegiance pairing does not exist." });
+    }
+  })
+  .get(async (req, res) => {
+    const { id } = req.params;
+    // Check if user to allegiance pairing exists
+    const userAllegiances = await UsersAllegiances.find({
+      "u_a.id": id
+    }).first();
+    if (userAllegiances) {
+      res.status(200).json({ userAllegiances });
+    } else {
+      res
+        .status(404)
+        .json({ message: "That user to allegiance pairing does not exist." });
+    }
+  });
 
 module.exports = router;


### PR DESCRIPTION
# Description

Added new delete endpoint for group_user, group_allegiance, and user_allegiance controllers that uses both foreign keys rather than the primary key, in case the front end doesn't have that handy and would have to make an API call for it anyway.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
